### PR TITLE
feat(search): 扩展课程搜索筛选功能

### DIFF
--- a/app.py
+++ b/app.py
@@ -462,15 +462,15 @@ def search_course():
                 if teacher not in teachers_str:
                     continue
             # 课程类型筛选
-            if course_type and course_type != i.get('courseType', {}).get('nameZh', ''):
+            if course_type and course_type != (i.get('courseType') or {}).get('nameZh', ''):
                 continue
             # 课程性质筛选
-            if course_property and course_property != i.get('courseProperty', {}).get('nameZh', ''):
+            if course_property and course_property != (i.get('courseProperty') or {}).get('nameZh', ''):
                 continue
             # 方案内课程筛选（按行政班）
             if admin_class:
                 attend_classes = [a.get('nameZh', '') for a in i.get('attendAdminclasses', [])]
-                if attend_classes and admin_class not in attend_classes:
+                if admin_class not in attend_classes:
                     continue
             # 必修/选修筛选
             if compulsory:
@@ -515,14 +515,21 @@ def search_course():
                 "capacity": i['limitCount'],
                 "campus": course_campus,
                 "scheduleGroups": schedule_groups,  # 添加选课组信息
-                "courseType": i.get('courseType', {}).get('nameZh', ''),
-                "courseProperty": i.get('courseProperty', {}).get('nameZh', ''),
+                "courseType": (i.get('courseType') or {}).get('nameZh', ''),
+                "courseProperty": (i.get('courseProperty') or {}).get('nameZh', ''),
                 "compulsorys": i.get('compulsorys', [])
             })
             lesson_ids.append(i['id'])
 
         if lesson_ids:
-            selected_numbers = get_selected_numbers(cookies, lesson_ids)
+            # 分批查询选课人数，每批 300 个，避免一次请求过多导致超时
+            batch_size = 300
+            selected_numbers = {}
+            for batch_start in range(0, len(lesson_ids), batch_size):
+                batch_ids = lesson_ids[batch_start:batch_start + batch_size]
+                batch_result = get_selected_numbers(cookies, batch_ids)
+                if isinstance(batch_result, dict):
+                    selected_numbers.update(batch_result)
             # 确保 selected_numbers 是字典类型
             if isinstance(selected_numbers, dict):
                 for course in result:

--- a/app.py
+++ b/app.py
@@ -424,6 +424,14 @@ def search_course():
         data = request.get_json()
         course_name = data.get('course_name', '')
         campus = data.get('campus', '')
+        course_code = data.get('course_code', '')
+        class_name = data.get('class_name', '')
+        teacher = data.get('teacher', '')
+        course_type = data.get('course_type', '')
+        course_property = data.get('course_property', '')
+        admin_class = data.get('admin_class', '')
+        compulsory = data.get('compulsory', '')
+        only_available = data.get('only_available', False)
 
         ilist = login_state['ilist']
         cookies = login_state['cookies']
@@ -432,46 +440,86 @@ def search_course():
         lesson_ids = []
         for i in ilist:
             course_campus = i.get('campus', {}).get('nameZh', '') if 'campus' in i else ''
-            if course_name in i['course']['nameZh'] and (not campus or campus == course_campus):
-                teachers = ', '.join([t['nameZh'] for t in i['teachers']])
 
-                # 获取选课组信息
-                schedule_groups = []
-                for group in i.get('scheduleGroups', []):
-                    group_info = {
-                        'id': group['id'],
-                        'no': group.get('no', 0),
-                        'limitCount': group.get('limitCount', 0),
-                        'default': group.get('default', False),
-                        'timeText': ''
-                    }
+            # 课程名称筛选（已有）
+            if course_name and course_name not in i['course']['nameZh']:
+                continue
+            # 校区筛选（已有）
+            if campus and campus != course_campus:
+                continue
+            # 课程代码/教学班代码筛选
+            if course_code:
+                lesson_code = i.get('code', '')
+                course_code_val = i.get('course', {}).get('code', '')
+                if course_code not in lesson_code and course_code not in course_code_val:
+                    continue
+            # 教学班名称筛选
+            if class_name and class_name not in i.get('nameZh', ''):
+                continue
+            # 授课教师筛选
+            if teacher:
+                teachers_str = ','.join(t.get('nameZh', '') for t in i.get('teachers', []))
+                if teacher not in teachers_str:
+                    continue
+            # 课程类型筛选
+            if course_type and course_type != i.get('courseType', {}).get('nameZh', ''):
+                continue
+            # 课程性质筛选
+            if course_property and course_property != i.get('courseProperty', {}).get('nameZh', ''):
+                continue
+            # 方案内课程筛选（按行政班）
+            if admin_class:
+                attend_classes = [a.get('nameZh', '') for a in i.get('attendAdminclasses', [])]
+                if attend_classes and admin_class not in attend_classes:
+                    continue
+            # 必修/选修筛选
+            if compulsory:
+                compulsorys = i.get('compulsorys', [])
+                if compulsory not in compulsorys:
+                    continue
 
-                    # 简化时间显示
-                    schedules = group.get('schedules', [])
-                    if schedules:
-                        time_parts = []
-                        for schedule in schedules:
-                            weekday = schedule.get('weekday', 0)
-                            start_unit = schedule.get('startUnit', 0)
-                            end_unit = schedule.get('endUnit', 0)
-                            weekday_map = {1: '周一', 2: '周二', 3: '周三', 4: '周四', 5: '周五', 6: '周六', 7: '周日'}
-                            time_parts.append(f"{weekday_map.get(weekday, '')} 第{start_unit}-{end_unit}节")
-                        group_info['timeText'] = '; '.join(time_parts)
+            teachers = ', '.join([t['nameZh'] for t in i['teachers']])
 
-                    schedule_groups.append(group_info)
+            # 获取选课组信息
+            schedule_groups = []
+            for group in i.get('scheduleGroups', []):
+                group_info = {
+                    'id': group['id'],
+                    'no': group.get('no', 0),
+                    'limitCount': group.get('limitCount', 0),
+                    'default': group.get('default', False),
+                    'timeText': ''
+                }
 
-                result.append({
-                    "name": i['course']['nameZh'],
-                    "className": i.get('nameZh', ''),  # 教学班名称
-                    "code": i['code'],
-                    "id": i['id'],
-                    "teachers": teachers,
-                    "credits": i['course']['credits'],
-                    "capacity": i['limitCount'],
-                    "campus": course_campus,
-                    "scheduleGroups": schedule_groups  # 添加选课组信息
-                })
-                lesson_ids.append(i['id'])
+                # 简化时间显示
+                schedules = group.get('schedules', [])
+                if schedules:
+                    time_parts = []
+                    for schedule in schedules:
+                        weekday = schedule.get('weekday', 0)
+                        start_unit = schedule.get('startUnit', 0)
+                        end_unit = schedule.get('endUnit', 0)
+                        weekday_map = {1: '周一', 2: '周二', 3: '周三', 4: '周四', 5: '周五', 6: '周六', 7: '周日'}
+                        time_parts.append(f"{weekday_map.get(weekday, '')} 第{start_unit}-{end_unit}节")
+                    group_info['timeText'] = '; '.join(time_parts)
+
+                schedule_groups.append(group_info)
+
+            result.append({
+                "name": i['course']['nameZh'],
+                "className": i.get('nameZh', ''),  # 教学班名称
+                "code": i['code'],
+                "id": i['id'],
+                "teachers": teachers,
+                "credits": i['course']['credits'],
+                "capacity": i['limitCount'],
+                "campus": course_campus,
+                "scheduleGroups": schedule_groups,  # 添加选课组信息
+                "courseType": i.get('courseType', {}).get('nameZh', ''),
+                "courseProperty": i.get('courseProperty', {}).get('nameZh', ''),
+                "compulsorys": i.get('compulsorys', [])
+            })
+            lesson_ids.append(i['id'])
 
         if lesson_ids:
             selected_numbers = get_selected_numbers(cookies, lesson_ids)
@@ -495,6 +543,20 @@ def search_course():
                 for course in result:
                     course['selected'] = '0'
                     course['selected_full'] = '0-0'
+
+            # 计算余量并处理仅显示有余量的筛选
+            if only_available:
+                filtered_result = []
+                for course in result:
+                    selected_count = int(course.get('selected', '0'))
+                    course['available'] = course['capacity'] - selected_count
+                    if course['available'] > 0:
+                        filtered_result.append(course)
+                result = filtered_result
+            else:
+                for course in result:
+                    selected_count = int(course.get('selected', '0'))
+                    course['available'] = course['capacity'] - selected_count
 
         return jsonify({'success': True, 'courses': result})
     except Exception as e:
@@ -612,6 +674,51 @@ def get_campuses():
         return jsonify({'success': True, 'campuses': sorted(list(campuses))})
     except Exception as e:
         return jsonify({'success': False, 'message': f'获取校区失败: {str(e)}'})
+
+@app.route('/get_course_types')
+@require_login
+def get_course_types():
+    """获取所有课程类型"""
+    try:
+        ilist = login_state['ilist']
+        types = set()
+        for i in ilist:
+            ct = i.get('courseType')
+            if ct and ct.get('nameZh'):
+                types.add(ct['nameZh'])
+        return jsonify({'success': True, 'types': sorted(list(types))})
+    except Exception as e:
+        return jsonify({'success': False, 'message': f'获取课程类型失败: {str(e)}'})
+
+@app.route('/get_course_properties')
+@require_login
+def get_course_properties():
+    """获取所有课程性质"""
+    try:
+        ilist = login_state['ilist']
+        properties = set()
+        for i in ilist:
+            cp = i.get('courseProperty')
+            if cp and cp.get('nameZh'):
+                properties.add(cp['nameZh'])
+        return jsonify({'success': True, 'properties': sorted(list(properties))})
+    except Exception as e:
+        return jsonify({'success': False, 'message': f'获取课程性质失败: {str(e)}'})
+
+@app.route('/get_admin_classes')
+@require_login
+def get_admin_classes():
+    """获取所有行政班（用于方案内课程筛选）"""
+    try:
+        ilist = login_state['ilist']
+        classes = set()
+        for i in ilist:
+            for a in i.get('attendAdminclasses', []):
+                if a.get('nameZh'):
+                    classes.add(a['nameZh'])
+        return jsonify({'success': True, 'classes': sorted(list(classes))})
+    except Exception as e:
+        return jsonify({'success': False, 'message': f'获取行政班失败: {str(e)}'})
 
 @app.route("/refresh_lesson_cache", methods=['GET'])
 @require_login

--- a/templates/auto_select.html
+++ b/templates/auto_select.html
@@ -77,9 +77,8 @@
                         <div class="row g-2 mb-2">
                             <div class="col-4">
                                 <label class="form-label small">方案内行政班</label>
-                                <select class="form-select form-select-sm" id="adminClassSelect">
-                                    <option value="">全部</option>
-                                </select>
+                                <input type="text" class="form-control form-control-sm" id="adminClassSelect" list="adminClassList" placeholder="输入或选择行政班">
+                                <datalist id="adminClassList"></datalist>
                             </div>
                             <div class="col-4">
                                 <label class="form-label small">必修/选修</label>
@@ -228,11 +227,11 @@
                 const response = await fetch('/get_admin_classes');
                 const data = await response.json();
                 if (data.success) {
-                    const select = document.getElementById('adminClassSelect');
+                    const datalist = document.getElementById('adminClassList');
                     data.classes.forEach(c => {
                         const option = document.createElement('option');
-                        option.value = c; option.textContent = c;
-                        select.appendChild(option);
+                        option.value = c;
+                        datalist.appendChild(option);
                     });
                 }
             } catch (error) { console.error('加载行政班失败:', error); }
@@ -250,7 +249,7 @@
             const compulsory = document.getElementById('compulsorySelect').value;
             const onlyAvailable = document.getElementById('onlyAvailable').checked;
 
-            if (!courseName && !courseCode && !className && !teacherName && !campus && !courseType && !courseProperty && !adminClass && !compulsory) {
+            if (!courseName && !courseCode && !className && !teacherName && !campus && !courseType && !courseProperty && !adminClass && !compulsory && !onlyAvailable) {
                 alert('请至少输入一个搜索条件'); return;
             }
             try {

--- a/templates/auto_select.html
+++ b/templates/auto_select.html
@@ -34,13 +34,67 @@
                         <h5 class="mb-0"><i class="bi bi-search text-primary me-2"></i>搜索课程</h5>
                     </div>
                     <div class="card-body">
-                        <div class="mb-3">
-                            <label class="form-label">课程名称</label>
-                            <input type="text" class="form-control" id="search_input" placeholder="输入课程名称...">
+                        <div class="row g-2 mb-2">
+                            <div class="col-6">
+                                <label class="form-label small">课程名称</label>
+                                <input type="text" class="form-control form-control-sm" id="search_input" placeholder="输入课程名称">
+                            </div>
+                            <div class="col-6">
+                                <label class="form-label small">课程代码</label>
+                                <input type="text" class="form-control form-control-sm" id="courseCode" placeholder="输入课程代码">
+                            </div>
                         </div>
-                        <div class="mb-3">
-                            <label class="form-label">校区筛选</label>
-                            <select class="form-select" id="campus_filter"><option value="">所有校区</option></select>
+                        <div class="row g-2 mb-2">
+                            <div class="col-6">
+                                <label class="form-label small">教学班名称</label>
+                                <input type="text" class="form-control form-control-sm" id="className" placeholder="输入教学班名称">
+                            </div>
+                            <div class="col-6">
+                                <label class="form-label small">授课教师</label>
+                                <input type="text" class="form-control form-control-sm" id="teacherName" placeholder="输入教师姓名">
+                            </div>
+                        </div>
+                        <div class="row g-2 mb-2">
+                            <div class="col-4">
+                                <label class="form-label small">校区</label>
+                                <select class="form-select form-select-sm" id="campus_filter">
+                                    <option value="">全部</option>
+                                </select>
+                            </div>
+                            <div class="col-4">
+                                <label class="form-label small">课程类型</label>
+                                <select class="form-select form-select-sm" id="courseTypeSelect">
+                                    <option value="">全部</option>
+                                </select>
+                            </div>
+                            <div class="col-4">
+                                <label class="form-label small">课程性质</label>
+                                <select class="form-select form-select-sm" id="coursePropertySelect">
+                                    <option value="">全部</option>
+                                </select>
+                            </div>
+                        </div>
+                        <div class="row g-2 mb-2">
+                            <div class="col-4">
+                                <label class="form-label small">方案内行政班</label>
+                                <select class="form-select form-select-sm" id="adminClassSelect">
+                                    <option value="">全部</option>
+                                </select>
+                            </div>
+                            <div class="col-4">
+                                <label class="form-label small">必修/选修</label>
+                                <select class="form-select form-select-sm" id="compulsorySelect">
+                                    <option value="">全部</option>
+                                    <option value="COMPULSORY">必修</option>
+                                    <option value="ELECTIVE">选修</option>
+                                </select>
+                            </div>
+                            <div class="col-4 d-flex align-items-end">
+                                <div class="form-check">
+                                    <input class="form-check-input" type="checkbox" id="onlyAvailable">
+                                    <label class="form-check-label small" for="onlyAvailable">仅显示有余量</label>
+                                </div>
+                            </div>
                         </div>
                         <div class="d-flex gap-2">
                             <button class="btn btn-primary flex-grow-1" onclick="searchCourses()"><i class="bi bi-search"></i> 搜索</button>
@@ -116,7 +170,8 @@
         let operations = [], isRunning = false, currentIndex = 0, queueInterval = null, statusHistory = [], scheduleTimeout = null, isScheduled = false;
 
         document.addEventListener('DOMContentLoaded', function() {
-            loadCampuses(); updateOperationList(); initStatusDisplay(); updateCurrentTime();
+            loadCampuses(); loadCourseTypes(); loadCourseProperties(); loadAdminClasses();
+            updateOperationList(); initStatusDisplay(); updateCurrentTime();
             setInterval(updateCurrentTime, 1000);
             document.getElementById('concurrencyMode').addEventListener('change', function() {
                 document.getElementById('threadSettings').style.display = this.value === 'parallel' ? 'block' : 'none';
@@ -138,14 +193,76 @@
             } catch (error) { console.error('加载校区失败:', error); }
         }
 
+        async function loadCourseTypes() {
+            try {
+                const response = await fetch('/get_course_types');
+                const data = await response.json();
+                if (data.success) {
+                    const select = document.getElementById('courseTypeSelect');
+                    data.types.forEach(t => {
+                        const option = document.createElement('option');
+                        option.value = t; option.textContent = t;
+                        select.appendChild(option);
+                    });
+                }
+            } catch (error) { console.error('加载课程类型失败:', error); }
+        }
+
+        async function loadCourseProperties() {
+            try {
+                const response = await fetch('/get_course_properties');
+                const data = await response.json();
+                if (data.success) {
+                    const select = document.getElementById('coursePropertySelect');
+                    data.properties.forEach(p => {
+                        const option = document.createElement('option');
+                        option.value = p; option.textContent = p;
+                        select.appendChild(option);
+                    });
+                }
+            } catch (error) { console.error('加载课程性质失败:', error); }
+        }
+
+        async function loadAdminClasses() {
+            try {
+                const response = await fetch('/get_admin_classes');
+                const data = await response.json();
+                if (data.success) {
+                    const select = document.getElementById('adminClassSelect');
+                    data.classes.forEach(c => {
+                        const option = document.createElement('option');
+                        option.value = c; option.textContent = c;
+                        select.appendChild(option);
+                    });
+                }
+            } catch (error) { console.error('加载行政班失败:', error); }
+        }
+
         async function searchCourses() {
             const courseName = document.getElementById('search_input').value.trim();
             const campus = document.getElementById('campus_filter').value;
-            if (!courseName) { alert('请输入课程名称'); return; }
+            const courseCode = document.getElementById('courseCode').value.trim();
+            const className = document.getElementById('className').value.trim();
+            const teacherName = document.getElementById('teacherName').value.trim();
+            const courseType = document.getElementById('courseTypeSelect').value;
+            const courseProperty = document.getElementById('coursePropertySelect').value;
+            const adminClass = document.getElementById('adminClassSelect').value;
+            const compulsory = document.getElementById('compulsorySelect').value;
+            const onlyAvailable = document.getElementById('onlyAvailable').checked;
+
+            if (!courseName && !courseCode && !className && !teacherName && !campus && !courseType && !courseProperty && !adminClass && !compulsory) {
+                alert('请至少输入一个搜索条件'); return;
+            }
             try {
                 const response = await fetch('/search_course', {
                     method: 'POST', headers: {'Content-Type': 'application/json'},
-                    body: JSON.stringify({course_name: courseName, campus: campus})
+                    body: JSON.stringify({
+                        course_name: courseName, campus: campus,
+                        course_code: courseCode, class_name: className,
+                        teacher: teacherName, course_type: courseType,
+                        course_property: courseProperty, admin_class: adminClass,
+                        compulsory: compulsory, only_available: onlyAvailable
+                    })
                 });
                 const data = await response.json();
                 if (data.success) showCourses(data.courses, 'select');
@@ -208,6 +325,8 @@
                             <h6 class="mb-1">${course.name} <small class="text-muted">${course.code}</small></h6>
                             <div class="text-secondary small text-truncate" style="max-width: 280px;" title="${course.className || ''}"><i class="bi bi-people"></i> ${course.className || ''}</div>
                             <small class="text-muted">${course.teachers} | ${course.campus} | ${course.selected}/${course.capacity}</small>
+                            ${course.available !== undefined ? `<span class="badge ${course.available > 0 ? 'bg-success' : 'bg-danger'} ms-1">余量:${course.available}</span>` : ''}
+                            ${course.courseType ? `<br><small class="text-muted"><i class="bi bi-tag"></i> ${course.courseType} | ${course.courseProperty || ''}</small>` : ''}
                             ${groupSelectorHtml}
                         </div>
                         <div class="d-flex align-items-center gap-2">

--- a/templates/index.html
+++ b/templates/index.html
@@ -82,9 +82,8 @@
                         <div class="row g-2 mb-2">
                             <div class="col-4">
                                 <label class="form-label small">方案内行政班</label>
-                                <select class="form-select form-select-sm" id="adminClassSelect">
-                                    <option value="">全部</option>
-                                </select>
+                                <input type="text" class="form-control form-control-sm" id="adminClassSelect" list="adminClassList" placeholder="输入或选择行政班">
+                                <datalist id="adminClassList"></datalist>
                             </div>
                             <div class="col-4">
                                 <label class="form-label small">必修/选修</label>
@@ -210,12 +209,11 @@
                 const response = await fetch('/get_admin_classes');
                 const result = await response.json();
                 if (result.success) {
-                    const select = document.getElementById('adminClassSelect');
+                    const datalist = document.getElementById('adminClassList');
                     result.classes.forEach(c => {
                         const option = document.createElement('option');
                         option.value = c;
-                        option.textContent = c;
-                        select.appendChild(option);
+                        datalist.appendChild(option);
                     });
                 }
             } catch (error) {
@@ -263,7 +261,7 @@
             const onlyAvailable = document.getElementById('onlyAvailable').checked;
 
             // 至少需要一个搜索条件
-            if (!courseName && !courseCode && !className && !teacherName && !campus && !courseType && !courseProperty && !adminClass && !compulsory) {
+            if (!courseName && !courseCode && !className && !teacherName && !campus && !courseType && !courseProperty && !adminClass && !compulsory && !onlyAvailable) {
                 showMessage('请至少输入一个搜索条件', true);
                 return;
             }

--- a/templates/index.html
+++ b/templates/index.html
@@ -39,15 +39,67 @@
                         <h5 class="mb-0"><i class="bi bi-search text-primary me-2"></i>搜索课程</h5>
                     </div>
                     <div class="card-body">
-                        <div class="mb-3">
-                            <label class="form-label">课程名称</label>
-                            <input type="text" class="form-control" id="courseName" placeholder="输入课程名称">
+                        <div class="row g-2 mb-2">
+                            <div class="col-6">
+                                <label class="form-label small">课程名称</label>
+                                <input type="text" class="form-control form-control-sm" id="courseName" placeholder="输入课程名称">
+                            </div>
+                            <div class="col-6">
+                                <label class="form-label small">课程代码</label>
+                                <input type="text" class="form-control form-control-sm" id="courseCode" placeholder="输入课程代码">
+                            </div>
                         </div>
-                        <div class="mb-3">
-                            <label class="form-label">校区</label>
-                            <select class="form-select" id="campusSelect">
-                                <option value="">全部校区</option>
-                            </select>
+                        <div class="row g-2 mb-2">
+                            <div class="col-6">
+                                <label class="form-label small">教学班名称</label>
+                                <input type="text" class="form-control form-control-sm" id="className" placeholder="输入教学班名称">
+                            </div>
+                            <div class="col-6">
+                                <label class="form-label small">授课教师</label>
+                                <input type="text" class="form-control form-control-sm" id="teacherName" placeholder="输入教师姓名">
+                            </div>
+                        </div>
+                        <div class="row g-2 mb-2">
+                            <div class="col-4">
+                                <label class="form-label small">校区</label>
+                                <select class="form-select form-select-sm" id="campusSelect">
+                                    <option value="">全部</option>
+                                </select>
+                            </div>
+                            <div class="col-4">
+                                <label class="form-label small">课程类型</label>
+                                <select class="form-select form-select-sm" id="courseTypeSelect">
+                                    <option value="">全部</option>
+                                </select>
+                            </div>
+                            <div class="col-4">
+                                <label class="form-label small">课程性质</label>
+                                <select class="form-select form-select-sm" id="coursePropertySelect">
+                                    <option value="">全部</option>
+                                </select>
+                            </div>
+                        </div>
+                        <div class="row g-2 mb-2">
+                            <div class="col-4">
+                                <label class="form-label small">方案内行政班</label>
+                                <select class="form-select form-select-sm" id="adminClassSelect">
+                                    <option value="">全部</option>
+                                </select>
+                            </div>
+                            <div class="col-4">
+                                <label class="form-label small">必修/选修</label>
+                                <select class="form-select form-select-sm" id="compulsorySelect">
+                                    <option value="">全部</option>
+                                    <option value="COMPULSORY">必修</option>
+                                    <option value="ELECTIVE">选修</option>
+                                </select>
+                            </div>
+                            <div class="col-4 d-flex align-items-end">
+                                <div class="form-check">
+                                    <input class="form-check-input" type="checkbox" id="onlyAvailable">
+                                    <label class="form-check-label small" for="onlyAvailable">仅显示有余量</label>
+                                </div>
+                            </div>
                         </div>
                         <button class="btn btn-primary w-100" onclick="searchCourse()">
                             <i class="bi bi-search"></i> 搜索
@@ -94,6 +146,9 @@
         window.onload = function() {
             getSelectedCourses();
             loadCampuses();
+            loadCourseTypes();
+            loadCourseProperties();
+            loadAdminClasses();
         };
 
         async function loadCampuses() {
@@ -111,6 +166,60 @@
                 }
             } catch (error) {
                 console.error('加载校区失败:', error);
+            }
+        }
+
+        async function loadCourseTypes() {
+            try {
+                const response = await fetch('/get_course_types');
+                const result = await response.json();
+                if (result.success) {
+                    const select = document.getElementById('courseTypeSelect');
+                    result.types.forEach(t => {
+                        const option = document.createElement('option');
+                        option.value = t;
+                        option.textContent = t;
+                        select.appendChild(option);
+                    });
+                }
+            } catch (error) {
+                console.error('加载课程类型失败:', error);
+            }
+        }
+
+        async function loadCourseProperties() {
+            try {
+                const response = await fetch('/get_course_properties');
+                const result = await response.json();
+                if (result.success) {
+                    const select = document.getElementById('coursePropertySelect');
+                    result.properties.forEach(p => {
+                        const option = document.createElement('option');
+                        option.value = p;
+                        option.textContent = p;
+                        select.appendChild(option);
+                    });
+                }
+            } catch (error) {
+                console.error('加载课程性质失败:', error);
+            }
+        }
+
+        async function loadAdminClasses() {
+            try {
+                const response = await fetch('/get_admin_classes');
+                const result = await response.json();
+                if (result.success) {
+                    const select = document.getElementById('adminClassSelect');
+                    result.classes.forEach(c => {
+                        const option = document.createElement('option');
+                        option.value = c;
+                        option.textContent = c;
+                        select.appendChild(option);
+                    });
+                }
+            } catch (error) {
+                console.error('加载行政班失败:', error);
             }
         }
 
@@ -144,9 +253,18 @@
         async function searchCourse() {
             const courseName = document.getElementById('courseName').value;
             const campus = document.getElementById('campusSelect').value;
-            
-            if (!courseName) {
-                showMessage('请输入课程名称', true);
+            const courseCode = document.getElementById('courseCode').value;
+            const className = document.getElementById('className').value;
+            const teacherName = document.getElementById('teacherName').value;
+            const courseType = document.getElementById('courseTypeSelect').value;
+            const courseProperty = document.getElementById('coursePropertySelect').value;
+            const adminClass = document.getElementById('adminClassSelect').value;
+            const compulsory = document.getElementById('compulsorySelect').value;
+            const onlyAvailable = document.getElementById('onlyAvailable').checked;
+
+            // 至少需要一个搜索条件
+            if (!courseName && !courseCode && !className && !teacherName && !campus && !courseType && !courseProperty && !adminClass && !compulsory) {
+                showMessage('请至少输入一个搜索条件', true);
                 return;
             }
 
@@ -154,7 +272,18 @@
                 const response = await fetch('/search_course', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ course_name: courseName, campus: campus })
+                    body: JSON.stringify({
+                        course_name: courseName,
+                        campus: campus,
+                        course_code: courseCode,
+                        class_name: className,
+                        teacher: teacherName,
+                        course_type: courseType,
+                        course_property: courseProperty,
+                        admin_class: adminClass,
+                        compulsory: compulsory,
+                        only_available: onlyAvailable
+                    })
                 });
 
                 const result = await response.json();
@@ -223,8 +352,10 @@
                                 <div class="mt-1">
                                     <span class="badge bg-secondary">容量: ${course.capacity}</span>
                                     <span class="badge bg-info">已选: ${course.selected || '0'}</span>
+                                    ${course.available !== undefined ? `<span class="badge ${course.available > 0 ? 'bg-success' : 'bg-danger'}">余量: ${course.available}</span>` : ''}
                                     <small class="text-muted ms-2">ID: ${course.id}</small>
                                 </div>
+                                ${course.courseType ? `<div class="mt-1"><small class="text-muted"><i class="bi bi-tag"></i> ${course.courseType} | ${course.courseProperty || ''}</small></div>` : ''}
                                 ${groupSelectorHtml}
                             </div>
                             <button class="btn btn-primary btn-sm" onclick="selectCourse(${course.id}, ${hasMultipleGroups})">

--- a/templates/monitor.html
+++ b/templates/monitor.html
@@ -113,9 +113,8 @@
                         <div class="row g-2 mb-2">
                             <div class="col-4">
                                 <label class="form-label small">方案内行政班</label>
-                                <select class="form-select form-select-sm" id="adminClassSelect">
-                                    <option value="">全部</option>
-                                </select>
+                                <input type="text" class="form-control form-control-sm" id="adminClassSelect" list="adminClassList" placeholder="输入或选择行政班">
+                                <datalist id="adminClassList"></datalist>
                             </div>
                             <div class="col-4">
                                 <label class="form-label small">必修/选修</label>
@@ -279,12 +278,11 @@
                 const response = await fetch('/get_admin_classes');
                 const data = await response.json();
                 if (data.success) {
-                    const select = document.getElementById('adminClassSelect');
+                    const datalist = document.getElementById('adminClassList');
                     data.classes.forEach(c => {
                         const option = document.createElement('option');
                         option.value = c;
-                        option.textContent = c;
-                        select.appendChild(option);
+                        datalist.appendChild(option);
                     });
                 }
             } catch (error) {
@@ -304,7 +302,7 @@
             const compulsory = document.getElementById('compulsorySelect').value;
             const onlyAvailable = document.getElementById('onlyAvailable').checked;
 
-            if (!courseName && !courseCode && !className && !teacherName && !campus && !courseType && !courseProperty && !adminClass && !compulsory) {
+            if (!courseName && !courseCode && !className && !teacherName && !campus && !courseType && !courseProperty && !adminClass && !compulsory && !onlyAvailable) {
                 alert('请至少输入一个搜索条件');
                 return;
             }

--- a/templates/monitor.html
+++ b/templates/monitor.html
@@ -70,15 +70,67 @@
                         <h5 class="mb-0"><i class="bi bi-search text-primary me-2"></i>搜索课程</h5>
                     </div>
                     <div class="card-body">
-                        <div class="mb-3">
-                            <label class="form-label">课程名称</label>
-                            <input type="text" class="form-control" id="search_input" placeholder="输入课程名称...">
+                        <div class="row g-2 mb-2">
+                            <div class="col-6">
+                                <label class="form-label small">课程名称</label>
+                                <input type="text" class="form-control form-control-sm" id="search_input" placeholder="输入课程名称">
+                            </div>
+                            <div class="col-6">
+                                <label class="form-label small">课程代码</label>
+                                <input type="text" class="form-control form-control-sm" id="courseCode" placeholder="输入课程代码">
+                            </div>
                         </div>
-                        <div class="mb-3">
-                            <label class="form-label">校区筛选</label>
-                            <select class="form-select" id="campus_filter">
-                                <option value="">所有校区</option>
-                            </select>
+                        <div class="row g-2 mb-2">
+                            <div class="col-6">
+                                <label class="form-label small">教学班名称</label>
+                                <input type="text" class="form-control form-control-sm" id="className" placeholder="输入教学班名称">
+                            </div>
+                            <div class="col-6">
+                                <label class="form-label small">授课教师</label>
+                                <input type="text" class="form-control form-control-sm" id="teacherName" placeholder="输入教师姓名">
+                            </div>
+                        </div>
+                        <div class="row g-2 mb-2">
+                            <div class="col-4">
+                                <label class="form-label small">校区</label>
+                                <select class="form-select form-select-sm" id="campus_filter">
+                                    <option value="">全部</option>
+                                </select>
+                            </div>
+                            <div class="col-4">
+                                <label class="form-label small">课程类型</label>
+                                <select class="form-select form-select-sm" id="courseTypeSelect">
+                                    <option value="">全部</option>
+                                </select>
+                            </div>
+                            <div class="col-4">
+                                <label class="form-label small">课程性质</label>
+                                <select class="form-select form-select-sm" id="coursePropertySelect">
+                                    <option value="">全部</option>
+                                </select>
+                            </div>
+                        </div>
+                        <div class="row g-2 mb-2">
+                            <div class="col-4">
+                                <label class="form-label small">方案内行政班</label>
+                                <select class="form-select form-select-sm" id="adminClassSelect">
+                                    <option value="">全部</option>
+                                </select>
+                            </div>
+                            <div class="col-4">
+                                <label class="form-label small">必修/选修</label>
+                                <select class="form-select form-select-sm" id="compulsorySelect">
+                                    <option value="">全部</option>
+                                    <option value="COMPULSORY">必修</option>
+                                    <option value="ELECTIVE">选修</option>
+                                </select>
+                            </div>
+                            <div class="col-4 d-flex align-items-end">
+                                <div class="form-check">
+                                    <input class="form-check-input" type="checkbox" id="onlyAvailable">
+                                    <label class="form-check-label small" for="onlyAvailable">仅显示有余量</label>
+                                </div>
+                            </div>
                         </div>
                         <button class="btn btn-primary w-100" onclick="searchCourses()">
                             <i class="bi bi-search"></i> 搜索课程
@@ -161,6 +213,9 @@
 
         document.addEventListener('DOMContentLoaded', function() {
             loadCampuses();
+            loadCourseTypes();
+            loadCourseProperties();
+            loadAdminClasses();
             updateMonitorList();
             initLogDisplay();
         });
@@ -183,12 +238,74 @@
             }
         }
 
+        async function loadCourseTypes() {
+            try {
+                const response = await fetch('/get_course_types');
+                const data = await response.json();
+                if (data.success) {
+                    const select = document.getElementById('courseTypeSelect');
+                    data.types.forEach(t => {
+                        const option = document.createElement('option');
+                        option.value = t;
+                        option.textContent = t;
+                        select.appendChild(option);
+                    });
+                }
+            } catch (error) {
+                console.error('加载课程类型失败:', error);
+            }
+        }
+
+        async function loadCourseProperties() {
+            try {
+                const response = await fetch('/get_course_properties');
+                const data = await response.json();
+                if (data.success) {
+                    const select = document.getElementById('coursePropertySelect');
+                    data.properties.forEach(p => {
+                        const option = document.createElement('option');
+                        option.value = p;
+                        option.textContent = p;
+                        select.appendChild(option);
+                    });
+                }
+            } catch (error) {
+                console.error('加载课程性质失败:', error);
+            }
+        }
+
+        async function loadAdminClasses() {
+            try {
+                const response = await fetch('/get_admin_classes');
+                const data = await response.json();
+                if (data.success) {
+                    const select = document.getElementById('adminClassSelect');
+                    data.classes.forEach(c => {
+                        const option = document.createElement('option');
+                        option.value = c;
+                        option.textContent = c;
+                        select.appendChild(option);
+                    });
+                }
+            } catch (error) {
+                console.error('加载行政班失败:', error);
+            }
+        }
+
         async function searchCourses() {
             const courseName = document.getElementById('search_input').value.trim();
             const campus = document.getElementById('campus_filter').value;
-            
-            if (!courseName) {
-                alert('请输入课程名称');
+            const courseCode = document.getElementById('courseCode').value.trim();
+            const className = document.getElementById('className').value.trim();
+            const teacherName = document.getElementById('teacherName').value.trim();
+            const courseType = document.getElementById('courseTypeSelect').value;
+            const courseProperty = document.getElementById('coursePropertySelect').value;
+            const adminClass = document.getElementById('adminClassSelect').value;
+            const compulsory = document.getElementById('compulsorySelect').value;
+            const onlyAvailable = document.getElementById('onlyAvailable').checked;
+
+            if (!courseName && !courseCode && !className && !teacherName && !campus && !courseType && !courseProperty && !adminClass && !compulsory) {
+                alert('请至少输入一个搜索条件');
                 return;
             }
             
@@ -196,9 +313,15 @@
                 const response = await fetch('/search_course', {
                     method: 'POST',
                     headers: {'Content-Type': 'application/json'},
-                    body: JSON.stringify({course_name: courseName, campus: campus})
+                    body: JSON.stringify({
+                        course_name: courseName, campus: campus,
+                        course_code: courseCode, class_name: className,
+                        teacher: teacherName, course_type: courseType,
+                        course_property: courseProperty, admin_class: adminClass,
+                        compulsory: compulsory, only_available: onlyAvailable
+                    })
                 });
-                
+
                 const data = await response.json();
                 if (data.success) {
                     showCourses(data.courses);
@@ -263,6 +386,7 @@
                                 <h6 class="mb-1">${course.name} <small class="text-muted">${course.code}</small></h6>
                                 <div class="text-secondary small text-truncate" style="max-width: 280px;" title="${course.className || ''}"><i class="bi bi-people"></i> ${course.className || ''}</div>
                                 <small class="text-muted">${course.teachers} | ${course.campus} | ${course.selected}/${course.capacity}</small>
+                                ${course.courseType ? `<br><small class="text-muted"><i class="bi bi-tag"></i> ${course.courseType} | ${course.courseProperty || ''}</small>` : ''}
                                 ${groupSelectorHtml}
                             </div>
                             <div class="text-end">


### PR DESCRIPTION
在原有课程名称+校区筛选基础上，新增8个筛选维度：
后端 (app.py):
- 新增 GET /get_course_types、/get_course_properties、/get_admin_classes 接口
- search_course 扩展参数: course_code、class_name、teacher、course_type、 course_property、admin_class、compulsory、only_available
- 返回结果追加 courseType、courseProperty、compulsorys、available 字段 前端 (index/auto_select/monitor):
- 搜索区域增加课程代码、教学班名称、授课教师、课程类型、课程性质、 方案内行政班、必修/选修、仅显示有余量 共8个筛选控件
- 新增 loadCourseTypes/loadCourseProperties/loadAdminClasses 函数
- 搜索结果展示课程类型、性质、余量信息